### PR TITLE
ダイアログをコンポーネント化

### DIFF
--- a/voicevox_src/src/components/UpdateNotificationDialog.vue
+++ b/voicevox_src/src/components/UpdateNotificationDialog.vue
@@ -1,31 +1,46 @@
 <template>
-    <q-dialog v-if="props.isUpdateAvailable" v-model="showUpdateNotificationDialog">
-        <q-card>
-            <q-card-section class="text-h6">
-                新しいアップデートがあります！
-            </q-card-section>
-            <q-card-section>
-                <!-- href の前にコロンつけないとダメ -->
-                <q-btn color="primary" :href="props.downloadLink" tag="a" target="_blank" label="ダウンロードページへ"
-                    @click="closeUpdateNotificationDialog" />
-                <q-btn label="後で" @click="closeUpdateNotificationDialog" />
-            </q-card-section>
-        </q-card>
+    <q-dialog v-model="modelValueComputed">
+      <q-card>
+        <q-card-section class="text-h6">
+          新しいアップデートがあります！
+        </q-card-section>
+        <q-card-section>
+          <!-- href の前にコロンつけないとダメ -->
+          <q-btn
+            color="primary"
+            :href="downloadLink"
+            tag="a"
+            target="_blank"
+            label="ダウンロードページへ"
+            @click="toDialogClosedState"
+          />
+          <q-btn label="後で" @click="toDialogClosedState" />
+        </q-card-section>
+      </q-card>
     </q-dialog>
-</template>
-
-<script setup lang="ts">
-import { ref } from "vue";
-
-const props =
+  </template>
+  
+  <script setup lang="ts">
+  import { computed } from "vue";
+  
+  const props =
     defineProps<{
-        downloadLink: string;
-        isUpdateAvailable: boolean;
+      modelValue: boolean;
     }>();
-
-const showUpdateNotificationDialog = ref(true);
-
-const closeUpdateNotificationDialog = () => {
-    showUpdateNotificationDialog.value = false;
-};
-</script>
+  const emit =
+    defineEmits<{
+      (e: "update:modelValue", val: boolean): void;
+    }>();
+  
+  const modelValueComputed = computed({
+    get: () => props.modelValue,
+    set: (val) => emit("update:modelValue", val),
+  });
+  
+  const toDialogClosedState = () => {
+    modelValueComputed.value = false;
+  };
+  
+  const downloadLink = "https://voicevox.hiroshiba.jp/";
+  </script>
+  

--- a/voicevox_src/src/components/UpdateNotificationDialog.vue
+++ b/voicevox_src/src/components/UpdateNotificationDialog.vue
@@ -1,0 +1,31 @@
+<template>
+    <q-dialog v-if="props.isUpdateAvailable" v-model="showUpdateNotificationDialog">
+        <q-card>
+            <q-card-section class="text-h6">
+                新しいアップデートがあります！
+            </q-card-section>
+            <q-card-section>
+                <!-- href の前にコロンつけないとダメ -->
+                <q-btn color="primary" :href="props.downloadLink" tag="a" target="_blank" label="ダウンロードページへ"
+                    @click="closeUpdateNotificationDialog" />
+                <q-btn label="後で" @click="closeUpdateNotificationDialog" />
+            </q-card-section>
+        </q-card>
+    </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+
+const props =
+    defineProps<{
+        downloadLink: string;
+        isUpdateAvailable: boolean;
+    }>();
+
+const showUpdateNotificationDialog = ref(true);
+
+const closeUpdateNotificationDialog = () => {
+    showUpdateNotificationDialog.value = false;
+};
+</script>

--- a/voicevox_src/src/views/EditorHome.vue
+++ b/voicevox_src/src/views/EditorHome.vue
@@ -8,8 +8,11 @@
       <q-page class="main-row-panes">
         <progress-dialog />
         <!-- アップデート可能ダイアログ -->
-        <!-- なぜかパスカルケースとケバブケースが対応しているみたい & コロンつけないとバグる -->
-        <update-notification-dialog downloadLink="https://voicevox.hiroshiba.jp/" :is-update-available="true"/>
+        <!-- なぜかパスカルケースとケバブケースが対応しているみたい -->
+        <update-notification-dialog
+          v-if="isUpdateAvailable"
+          v-model="isUpdateNotificationDialogOpenComputed"
+        />
 
         <!-- TODO: 複数エンジン対応 -->
         <!-- TODO: allEngineStateが "ERROR" のときエラーになったエンジンを探してトーストで案内 -->
@@ -218,7 +221,7 @@ import {
 } from "@/type/preload";
 import { isOnCommandOrCtrlKeyDown } from "@/store/utility";
 import { parseCombo, setHotkeyFunctions } from "@/store/setting";
-import UpdateNotificationDialog from "@/components/UpdateNotificationDialog.vue"
+import UpdateNotificationDialog from "@/components/UpdateNotificationDialog.vue";
 
 const props =
   defineProps<{
@@ -848,6 +851,16 @@ watch(activeAudioKey, (audioKey) => {
 const showAddAudioItemButton = computed(() => {
   return store.state.showAddAudioItemButton;
 });
+
+// アップデート可能ダイアログ
+const isUpdateAvailable = ref<boolean>(true);
+const isUpdateNotificationDialogOpenComputed = ref<boolean>(true);
+/* 他のis.*OpenComputedと同じように以下のようにしたい. type.tsとui.tsに追記する必要がある.
+= computed({
+  get: () => store.state.isUpdateNotificationDialogOpen,
+  set: (val) => store.dispatch("SET_DIALOG_OPEN", { isUpdateNotificationDialogOpen: val }),
+});
+*/
 </script>
 
 <style scoped lang="scss">

--- a/voicevox_src/src/views/EditorHome.vue
+++ b/voicevox_src/src/views/EditorHome.vue
@@ -7,6 +7,9 @@
     <q-page-container>
       <q-page class="main-row-panes">
         <progress-dialog />
+        <!-- アップデート可能ダイアログ -->
+        <!-- なぜかパスカルケースとケバブケースが対応しているみたい & コロンつけないとバグる -->
+        <update-notification-dialog downloadLink="https://voicevox.hiroshiba.jp/" :is-update-available="true"/>
 
         <!-- TODO: 複数エンジン対応 -->
         <!-- TODO: allEngineStateが "ERROR" のときエラーになったエンジンを探してトーストで案内 -->
@@ -44,23 +47,6 @@
               >
               <q-btn v-else outline @click="openQa">Q&Aを見る</q-btn>
             </template>
-	          <!-- ダイアログ テスト -->
-            <q-dialog v-model="showModal" v-if="props.isUpdateAvailable">
-              <q-card>
-                <q-card-section class="text-h6">
-                  新しいアップデートがあります！
-                </q-card-section>
-                <q-card-section>
-                  <q-btn color="primary"
-                    to="https://voicevox.hiroshiba.jp"
-                    tag="a"
-                    target="_blank"
-                    label="アップデートする"
-                    @click="closeModal" />
-                  <q-btn label="後で通知する" @click="closeModal" />
-                </q-card-section>
-              </q-card>
-            </q-dialog>
           </div>
         </div>
         <q-splitter
@@ -232,15 +218,11 @@ import {
 } from "@/type/preload";
 import { isOnCommandOrCtrlKeyDown } from "@/store/utility";
 import { parseCombo, setHotkeyFunctions } from "@/store/setting";
-import { UpdateInfo } from "@/type/preload";
+import UpdateNotificationDialog from "@/components/UpdateNotificationDialog.vue"
 
 const props =
   defineProps<{
     projectFilePath: string;
-    latestVersion: string;
-    downloadLink: string;
-    updateInfos: UpdateInfo[];
-    isUpdateAvailable: boolean;
   }>();
 
 const store = useStore();
@@ -866,12 +848,6 @@ watch(activeAudioKey, (audioKey) => {
 const showAddAudioItemButton = computed(() => {
   return store.state.showAddAudioItemButton;
 });
-
-const showModal = ref(true);
-
-function closeModal() {
-  showModal.value = false;
-}
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
アップデート可能ダイアログをEditorHome.vueに直接実装するのではなく, コンポーネントにして呼び出すようにした

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
